### PR TITLE
Run preprocessing with DVC

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ python -m venv shrubsenv
 pip install -e .
 ```
 
+## Run with DVC
+
+### Preprocessing
+
+This assumes you have the project raw data in `data/raw` and an empty directory in `data/interim`.
+Change into the `prepro` directory and run `dvc repro`.
+
+```
+cd prepro
+dvc repro
+```
+
+_Note - until we've got shared storage established, working copy of `data/raw` is on an external drive mounted in this directory, I've done this:_
+
+```
+cd prepro
+ln -s /media/zool/mounted_drive/mambo_data/Projs/mambo-dl/shrub-height/data/raw raw
+mkdir interim
+dvc repro
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ shrub-height/
 ├── README.md          # Project documentation
 └── requirements.txt   # Python dependencies
 ```
+## Installation
+
+### Install GDAL
+
+This will vary according to your platform. For Debian/Ubuntu, it's like this, and gives you version 3.6.2:
+
+`sudo apt install gdal-bin`
+
+### Create python environment and install dependencies
+
+The versions of GDAL and of its python bindings need to match. Thus `pyproject.toml` is currently pinned to 3.6.2
+
+```
+python -m venv shrubsenv
+pip install -e .
+```
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shrub-height"
+version = "0.1.0"
+requires-python = ">=3.9"
+description = "This package supports the processing and analysis of shrub heights from SfM, terrain and LiDAR data"
+readme = "README.md"
+dependencies = [
+  "dvc",
+  "numpy",
+  "pandas",
+  "geopandas",
+  "rasterio",
+  "gdal==3.6.2",
+  "scikit-learn"
+]
+
+[project.optional-dependencies]
+jupyter = ["jupyterlab", "jupytext", "matplotlib", "scikit-learn"]
+test = ["pytest", "pytest-cov", "pytest-mock", "parameterized"]
+lint = ["flake8", "isort", "ruff"]
+all = ["cyto_ml[jupyter,test,lint]"]
+
+[tool.jupytext]
+formats = "ipynb,md"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]
+
+[tool.ruff]
+src = ["src", "tests"]
+include = ["src/**.py"]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "E", "W", "A", "PLC", "PLE", "PLW", "I", "N816", "ANN001", "ANN201", "ANN202", "ANN205", "ANN206"]
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true

--- a/src/prepro/dvc.yaml
+++ b/src/prepro/dvc.yaml
@@ -1,0 +1,41 @@
+stages:
+  point2pol:
+    cmd: python src/prepro/point2pol.py
+    deps:
+      - src/prepro/point2pol.py
+      - data/raw/Field_measurements/shrub_clean.shp
+    outs:
+      - data/interim/field_pols.fgb
+
+  sfm_to_cog:
+    cmd: bash src/prepro/sfm_to_cog.sh
+    deps:
+      - src/prepro/sfm_to_cog.sh
+      - data/raw/SfM/strawberry_ortho_terraSfM_L1_apr24.tif
+    outs:
+      - data/interim/rgb_sfm.tif
+
+  normalize_dsm:
+    cmd: python src/prepro/normalize_dsm.py
+    deps:
+      - src/prepro/normalize_dsm.py
+      - data/raw/DTM-1m/TL06sw_DTM_1m.tif
+      - data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif
+    outs:
+      - data/interim/sfm_normalized.tif
+
+  manual_labeled:
+    cmd: python src/prepro/manual_labeled.py
+    deps:
+      - src/prepro/manual_labeled.py
+      - data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp
+    outs:
+      - data/interim/manual_pols.fgb
+
+  compute_slope:
+    cmd: bash src/prepro/compute_slope.sh
+    deps:
+      - src/prepro/compute_slope.sh
+      - data/interim/dsm_sfm.tif
+    outs:
+      - data/interim/slp_sfm.tif

--- a/src/prepro/dvc.yaml
+++ b/src/prepro/dvc.yaml
@@ -19,7 +19,7 @@ stages:
     cmd: python normalize_dsm.py
     deps:
       - normalize_dsm.py
-      - data/raw/DTM-1m/TL06sw_DTM_1m.tif
+      - data/raw/EA_1m/TL06sw_DTM_1m.tif
       - data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif
     outs:
       - data/interim/sfm_normalized.tif

--- a/src/prepro/dvc.yaml
+++ b/src/prepro/dvc.yaml
@@ -1,41 +1,41 @@
 stages:
   point2pol:
-    cmd: python src/prepro/point2pol.py
+    cmd: python point2pol.py
     deps:
-      - src/prepro/point2pol.py
+      - point2pol.py
       - data/raw/Field_measurements/shrub_clean.shp
     outs:
       - data/interim/field_pols.fgb
 
   sfm_to_cog:
-    cmd: bash src/prepro/sfm_to_cog.sh
+    cmd: bash sfm_to_cog.sh
     deps:
-      - src/prepro/sfm_to_cog.sh
+      - sfm_to_cog.sh
       - data/raw/SfM/strawberry_ortho_terraSfM_L1_apr24.tif
     outs:
       - data/interim/rgb_sfm.tif
 
   normalize_dsm:
-    cmd: python src/prepro/normalize_dsm.py
+    cmd: python normalize_dsm.py
     deps:
-      - src/prepro/normalize_dsm.py
+      - normalize_dsm.py
       - data/raw/DTM-1m/TL06sw_DTM_1m.tif
       - data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif
     outs:
       - data/interim/sfm_normalized.tif
 
   manual_labeled:
-    cmd: python src/prepro/manual_labeled.py
+    cmd: python manual_labeled.py
     deps:
-      - src/prepro/manual_labeled.py
+      - manual_labeled.py
       - data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp
     outs:
       - data/interim/manual_pols.fgb
 
   compute_slope:
-    cmd: bash src/prepro/compute_slope.sh
+    cmd: bash compute_slope.sh
     deps:
-      - src/prepro/compute_slope.sh
+      - compute_slope.sh
       - data/interim/dsm_sfm.tif
     outs:
       - data/interim/slp_sfm.tif

--- a/src/prepro/normalize_dsm.py
+++ b/src/prepro/normalize_dsm.py
@@ -12,7 +12,7 @@ import rasterio
 from rasterio.enums import Resampling
 from rasterio.warp import reproject, calculate_default_transform
 
-dtm_path = 'data/raw/DTM-1m/TL06sw_DTM_1m.tif'
+dtm_path = 'data/raw/EA_1m/TL06sw_DTM_1m.tif'
 folder_path = 'data/raw/SfM'
 dsm_path = 'data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif'
 output_folder = 'data/interim'


### PR DESCRIPTION
First steps towards making reproducible pipelines out of the data processing scripts

* Adds a `dvc.yaml` that runs the preprocessing scripts in sequence, with their inputs and outputs defined
* Adds a `pyproject.toml` for ease of installation of this project via `pip`
* Adds documentation on install and run to the `README.md`

I'll mark this as Draft while the pipeline is still running.

Next steps would be to

* Adapt the scripts so instead of reading and writing to hard-coded paths, they read those values from the `dvc.yaml` file 
* Keep the data itself in data version control, stored in s3 (once JASMIN is back!)
* If this looks good, then add the same pipeline setup to the data treatment and modelling scripts