### PR TITLE
Refactor for reusability

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A series of Python scripts to process LiDAR point clouds and SfM images at polyg
 
 - **Aggregate LiDAR Point Clouds (PCs) at individual shrubs**: `src/treatment/las_pc_at_shrubs.py`
     - input: 
-        - indivudal shrub polygons file
+        - indiviudal shrub polygons file
         - point clouds files directory (raw)
     - output: 
         - one file per individual shrub containing point clouds
@@ -65,7 +65,8 @@ This will vary according to your platform. For Debian/Ubuntu, it's like this, an
 The versions of GDAL and of its python bindings need to match. Thus `pyproject.toml` is currently pinned to 3.6.2
 
 ```
-python -m venv shrubsenv
+python -m venv .venv
+source .venv/bin/activate
 pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "geopandas",
   "rasterio",
   "gdal==3.6.2",
+  "laspy",
   "scikit-learn"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pandas
 geopandas
 rasterio
 gdal
+laspy
 scikit-learn

--- a/src/modelling/run.py
+++ b/src/modelling/run.py
@@ -1,59 +1,60 @@
-
 import os
-os.chdir('shrub-height')
+import logging
 
-import numpy as np
 import pandas as pd
-from src.modelling import utils as mlp # make sure it is added to path
 
+from src.modelling import utils as mlp  # make sure it is added to path
 
-df = pd.read_csv('data/processed/shrubs2ml.csv')
+os.chdir("shrub-height")
+df = pd.read_csv("data/processed/shrubs2ml.csv")
 df = df.dropna()
 
 # Choose target
-targets = ['h_lidar'] 
-models = ['MLR', 'SVM', 'GBM', 'RF'] 
+targets = ["h_lidar"]
+models = ["MLR", "SVM", "GBM", "RF"]
 features = df.columns.drop(targets)
 
-df = df.sample(frac = 1) # Shuffle values MAKES ALL THE DIFFERENCE IDKW
+df = df.sample(frac=1)  # Shuffle values MAKES ALL THE DIFFERENCE IDKW
 for target in targets:
     if df[target].isna().any():
-        method = 'dataset'
+        method = "dataset"
         selected_features = features
     else:
-        method = 'k-fold'
+        method = "k-fold"
         # Select features for modelling based on hyerarchical clustering
-        cluster_feature, selected_features = mlp.fs_hcluster(df,
-                                                              features, 
-                                                              target, 
-                                                              cluster_threshold=0.3, 
-                                                              plot=True)
+        cluster_feature, selected_features = mlp.fs_hcluster(
+            df, features, target, cluster_threshold=0.3, plot=True
+        )
     X = df[selected_features].values
     y = df[target].values
-    
+
     for mlmodel in models:
-        print('Running for ' + target + ' and ' + mlmodel)
-        yhat, imps = mlp.model_run(X,
-                                  y,
-                                  mlmodel,
-                                  method=method,
-                                  )
-        
+        print("Running for " + target + " and " + mlmodel)
+        yhat, imps = mlp.model_run(
+            X,
+            y,
+            mlmodel,
+            method=method,
+        )
+
         try:
             imps.columns = selected_features
             mlp.plot_results(y, yhat, imps, target, mlmodel, savefigs=False)
-        except:
+        except AttributeError as e:
+            logging.warning(f"Could not plot results - imp format incorrect: {e}")
             mlp.accuracy(y, yhat)
-        
+        except ValueError as e:
+            logging.warning(f"Could not plot results - feature mismatch: {e}")
+            mlp.accuracy(y, yhat)
+
         # Creating the DataFrame with specified columns and errors
         dfr = pd.DataFrame(index=df.index)
-        dfr['obs'] = y
-        dfr['pred'] = yhat
-        
-        imps.to_csv('data/output/imps_'+target+'_'+mlmodel+'_'+method+'.csv')
-        dfr.to_csv('data/output/results_raw_'+target+'_'+mlmodel+'_'+method+'.csv')
-        
-        
-        
-    
+        dfr["obs"] = y
+        dfr["pred"] = yhat
 
+        imps.to_csv(
+            "data/output/imps_" + target + "_" + mlmodel + "_" + method + ".csv"
+        )
+        dfr.to_csv(
+            "data/output/results_raw_" + target + "_" + mlmodel + "_" + method + ".csv"
+        )

--- a/src/modelling/utils.py
+++ b/src/modelling/utils.py
@@ -5,32 +5,34 @@ Created on Wed Nov 29 06:55:46 2023
 @author: RafBar
 """
 
-import numpy as np
-import pandas as pd
 import time
-
-from scipy.cluster import hierarchy
-from scipy.spatial.distance import squareform
 from collections import defaultdict
 
-from statsmodels.stats.outliers_influence import variance_inflation_factor
-
-from sklearn.decomposition import PCA
-from sklearn.model_selection import RandomizedSearchCV, KFold
-from sklearn.inspection import permutation_importance
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
-from sklearn.linear_model import LinearRegression
-from sklearn.tree import DecisionTreeRegressor
-from sklearn.neighbors import KNeighborsRegressor
-from sklearn.svm import SVR, SVC
-from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
-from sklearn.metrics import accuracy_score, classification_report
-
-from scipy.stats import randint, loguniform
-
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 import seaborn as sns
+from scipy.cluster import hierarchy
+from scipy.spatial.distance import squareform
+from scipy.stats import loguniform, randint
+from sklearn.decomposition import PCA
+from sklearn.ensemble import (
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+from sklearn.inspection import permutation_importance
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import accuracy_score, classification_report
+from sklearn.model_selection import KFold, RandomizedSearchCV
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
+from sklearn.svm import SVC, SVR
+from sklearn.tree import DecisionTreeRegressor
+from statsmodels.stats.outliers_influence import variance_inflation_factor
+import logging
+
 
 def fs_hcluster(df, features, target, cluster_threshold=0.4, plot=False):
     """
@@ -46,7 +48,7 @@ def fs_hcluster(df, features, target, cluster_threshold=0.4, plot=False):
     selected_features (list): The selected feature for model running.
     """
     # Compute the correlation matrix
-    dfcorr = df.corr(method='spearman').abs()
+    dfcorr = df.corr(method="spearman").abs()
     corr = dfcorr.loc[features, features].values
     corr = np.nan_to_num(corr)
 
@@ -59,31 +61,33 @@ def fs_hcluster(df, features, target, cluster_threshold=0.4, plot=False):
     dist_linkage = hierarchy.ward(squareform(distance_matrix))
 
     # Hierarchical clustering
-    cluster_ids = hierarchy.fcluster(dist_linkage, cluster_threshold, criterion="distance")
+    cluster_ids = hierarchy.fcluster(
+        dist_linkage, cluster_threshold, criterion="distance"
+    )
     cluster_id_to_feature_ids = defaultdict(list)
     cluster_feature = defaultdict(list)
     for idx, cluster_id in enumerate(cluster_ids):
         cluster_id_to_feature_ids[cluster_id].append(idx)
-        cluster_feature['Cluster '+str(cluster_id)].append(df.columns[idx])
-        
+        cluster_feature["Cluster " + str(cluster_id)].append(df.columns[idx])
+
     # Select features with the greatest correlation to the target
     selected_features = []
     for v in cluster_id_to_feature_ids.values():
         targetcorr = dfcorr[target].iloc[v].max()
         bestfeat = dfcorr.reset_index().index[dfcorr[target] == targetcorr].values[0]
         selected_features.append(df.columns[bestfeat])
-        
+
     # Plot the correlation matrix and the dendogram
     if plot:
-        fig, ax = plt.subplots(1, 1, figsize=(6,6), dpi=300)
+        fig, ax = plt.subplots(1, 1, figsize=(6, 6), dpi=300)
         dendro = hierarchy.dendrogram(
             dist_linkage, labels=features, ax=ax, leaf_rotation=90
         )
         dendro_idx = np.arange(0, len(dendro["ivl"]))
         fig.tight_layout()
         plt.show()
-        
-        fig, ax = plt.subplots(1, 1, figsize=(9,9), dpi=300)
+
+        fig, ax = plt.subplots(1, 1, figsize=(9, 9), dpi=300)
         ax.imshow(corr[dendro["leaves"], :][:, dendro["leaves"]])
         ax.set_xticks(dendro_idx)
         ax.set_yticks(dendro_idx)
@@ -91,51 +95,61 @@ def fs_hcluster(df, features, target, cluster_threshold=0.4, plot=False):
         ax.set_yticklabels(dendro["ivl"])
         fig.tight_layout()
         plt.show()
-        
-        fig, ax = plt.subplots(1, 1, figsize=(15,12), dpi=300)
-        sns.heatmap(abs(dfcorr), ax=ax, cmap='flare')
+
+        fig, ax = plt.subplots(1, 1, figsize=(15, 12), dpi=300)
+        sns.heatmap(abs(dfcorr), ax=ax, cmap="flare")
         fig.tight_layout()
         plt.show()
-    
+
     return cluster_feature, selected_features
 
+
 def pca_cluster_transform(df, cluster_feature):
-    
+
     X = MinMaxScaler().fit_transform(df.values)
-    
+
     pcs = {}
-    
+
     for cluster, features in cluster_feature.items():
         pca = PCA(n_components=1)  # Only the first principal component
-        pca.fit(X[:,features])
-        pcs[cluster] = pca.transform(X[:,features])
-        
+        pca.fit(X[:, features])
+        pcs[cluster] = pca.transform(X[:, features])
+
     feature_matrix = np.hstack([pcs[cluster] for cluster in sorted(pcs.keys())])
-    
+
     return feature_matrix
 
+
 def calculate_vif(df, thresh=10):
-    Xv = StandardScaler().fit_transform(df.values) # FOR THE VIF
-    dfi = pd.DataFrame(Xv, columns = df.columns)
-    
+    Xv = StandardScaler().fit_transform(df.values)  # FOR THE VIF
+    dfi = pd.DataFrame(Xv, columns=df.columns)
+
     variables = list(range(dfi.shape[1]))
     dropped = True
     while dropped:
         dropped = False
-        vif = [variance_inflation_factor(dfi.iloc[:, variables].values, ix)
-                for ix in range(dfi.iloc[:, variables].shape[1])]
+        vif = [
+            variance_inflation_factor(dfi.iloc[:, variables].values, ix)
+            for ix in range(dfi.iloc[:, variables].shape[1])
+        ]
         maxloc = vif.index(max(vif))
         if max(vif) > thresh:
-            print('dropping \'' + dfi.iloc[:, variables].columns[maxloc] +
-                  '\' at index: ' + str(maxloc) + '| with value: ' + str(max(vif))
-                  )
+            print(
+                "dropping '"
+                + dfi.iloc[:, variables].columns[maxloc]
+                + "' at index: "
+                + str(maxloc)
+                + "| with value: "
+                + str(max(vif))
+            )
             del variables[maxloc]
             dropped = True
 
-    print('Remaining variables:')
+    print("Remaining variables:")
     print(dfi.columns[variables])
-    
+
     return dfi.columns[variables]
+
 
 def kfold_cv(X, y, model, grid):
     """
@@ -152,52 +166,69 @@ def kfold_cv(X, y, model, grid):
     - imps (pd.DataFrame): DataFrame with feature importances.
     """
     n_splits = 10
-    cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)  # Ensure reproducibility
-    # yhat = np.zeros(y.size)
+    cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)
     yhat = np.empty(y.size, dtype=y.dtype)
-    imps = pd.DataFrame(columns=range(1, X.shape[1]+1), index=range(n_splits * 10))
-    i = 0
-    
+
+    # Create DataFrame for importance scores - 10 repeats per fold
+    n_features = X.shape[1]
+    n_importance_rows = n_splits * 10  # 10 repeats per fold
+    imps = pd.DataFrame(
+        columns=range(1, n_features + 1), index=range(n_importance_rows)
+    )
+
+    # Track current row in importance scores DataFrame
+    importance_row = 0
+
     for train_index, test_index in cv.split(X, y):
         y_pred, r = train_test(X, y, train_index, test_index, grid, model)
         yhat[test_index] = y_pred
-        imps.iloc[i:i+10, :] = r.importances.T
-        processing = (i // 10 + 1) * 100 / n_splits
-        print(f'Processing: {processing:.0f}%')
-        i += 10
+
+        # Store importance scores for this fold (10 rows)
+        imps.iloc[importance_row : importance_row + 10, :] = r.importances.T  # noqa: E203
+        importance_row += 10
+
+        fold_number = importance_row // 10
+        progress = fold_number * 100 / n_splits
+        print(f"Processing: {progress:.0f}%")
 
     return yhat, imps
+
 
 def train_test(X, y, train_index, test_index, grid, model):
     X_train, X_test = X[train_index], X[test_index]
     y_train, y_test = y[train_index], y[test_index]
-    
-    randomSearch = RandomizedSearchCV(estimator=model,
-                                      n_jobs=-1,
-                                      n_iter=100,
-                                      cv=5,
-                                      param_distributions=grid,
-                                      scoring="r2") # change to r2 for regression
+
+    randomSearch = RandomizedSearchCV(
+        estimator=model,
+        n_jobs=-1,
+        n_iter=100,
+        cv=5,
+        param_distributions=grid,
+        scoring="r2",
+    )  # change to r2 for regression
     searchResults = randomSearch.fit(X_train, y_train)
-    
-    print('\n')
-    print('Best score: ' + str(randomSearch.best_score_))
-    print('Best params: ' + str(randomSearch.best_params_) + '\n')
-    
+
+    print("\n")
+    print("Best score: " + str(randomSearch.best_score_))
+    print("Best params: " + str(randomSearch.best_params_) + "\n")
+
     model_opt = searchResults.best_estimator_
-    
+
     model_opt.fit(X_train, y_train)
     y_pred = model_opt.predict(X_test)
 
     try:
-        r = permutation_importance(model_opt, X_test, y_test, n_repeats=10, random_state=0, scoring='r2')
-    except:
+        r = permutation_importance(
+            model_opt, X_test, y_test, n_repeats=10, random_state=0, scoring="r2"
+        )
+    except Exception as e:
+        logging.warning(f"Could not compute permutation importance: {str(e)}")
         r = 0
-    
+
     return y_pred, r
 
 
-def model_run(X, y, mlmodel, method='kfold'):
+def model_run(X, y, mlmodel, method="kfold"):
     """
     Tune hyperparameters, train and test a machine learning model.
 
@@ -213,115 +244,132 @@ def model_run(X, y, mlmodel, method='kfold'):
     start_time = time.time()
 
     # Model selection
-    if mlmodel == 'MLR':
+    if mlmodel == "MLR":
         model = LinearRegression()
         grid = dict()
-    elif mlmodel == 'DT':
+    elif mlmodel == "DT":
         model = DecisionTreeRegressor()
         grid = dict(max_depth=randint(2, 20), min_samples_leaf=randint(5, 100))
-    elif mlmodel == 'KNN':
+    elif mlmodel == "KNN":
         model = KNeighborsRegressor()
-        grid = dict(leaf_size=randint(1, 50), n_neighbors=randint(1, 30), p=randint(1, 5))
-    elif mlmodel == 'SVM':
+        grid = dict(
+            leaf_size=randint(1, 50), n_neighbors=randint(1, 30), p=randint(1, 5)
+        )
+    elif mlmodel == "SVM":
         model = SVR()
         grid = dict(gamma=loguniform(1e-4, 1), C=loguniform(0.1, 100))
-    elif mlmodel == 'GBM':
+    elif mlmodel == "GBM":
         model = GradientBoostingRegressor()
-        grid = dict(n_estimators=randint(1, 500), max_leaf_nodes=randint(2, 100),
-                    learning_rate=loguniform(0.01, 1))
-    elif mlmodel == 'RF':
+        grid = dict(
+            n_estimators=randint(1, 500),
+            max_leaf_nodes=randint(2, 100),
+            learning_rate=loguniform(0.01, 1),
+        )
+    elif mlmodel == "RF":
         model = RandomForestRegressor()
         grid = dict(n_estimators=randint(1, 500), max_leaf_nodes=randint(2, 100))
-    elif mlmodel == 'SVM_C':
+    elif mlmodel == "SVM_C":
         model = SVC()
         grid = dict(gamma=loguniform(1e-4, 1), C=loguniform(0.1, 100))
-    elif mlmodel == 'GBM_C':
+    elif mlmodel == "GBM_C":
         model = GradientBoostingClassifier()
-        grid = dict(n_estimators=randint(1, 500), max_leaf_nodes=randint(2, 100),
-                    learning_rate=loguniform(0.01, 1))
-    elif mlmodel == 'RF_C':
+        grid = dict(
+            n_estimators=randint(1, 500),
+            max_leaf_nodes=randint(2, 100),
+            learning_rate=loguniform(0.01, 1),
+        )
+    elif mlmodel == "RF_C":
         model = RandomForestClassifier()
         grid = dict(n_estimators=randint(1, 500), max_leaf_nodes=randint(2, 100))
     else:
-        raise ValueError('Please provide a valid ML model type!')
-    
+        raise ValueError("Please provide a valid ML model type!")
+
     # Prepare data
     X = MinMaxScaler().fit_transform(X)
-    
-    ## 10-Fold Cross Validation
-    if method=='k-fold':
+
+    # 10-Fold Cross Validation
+    if method == "k-fold":
         yhat, imps = kfold_cv(X, y, model, grid)
 
-    elif method=='dataset':
+    elif method == "dataset":
         train_index = ~np.isnan(y)
         test_index = [True] * train_index.size
         yhat, imps = train_test(X, y, train_index, test_index, grid, model)
     else:
-        return print('PROVIDE VALID METHOD')
+        return print("PROVIDE VALID METHOD")
 
     end_time = time.time()
-    print('\n' + mlmodel + ' | Time to process: ' + str((end_time - start_time) / 60) + ' min \n')
-    
+    print(
+        "\n"
+        + mlmodel
+        + " | Time to process: "
+        + str((end_time - start_time) / 60)
+        + " min \n"
+    )
+
     return yhat, imps
 
+
 def stats(s1, s2):
-    rq75 = np.percentile(np.maximum(abs(s1/s2), abs(s2/s1)), 75)
-    r2 = 1 - ((s2-s1)**2).sum()/((s2-s2.mean())**2).sum() # == nash
-    rmse = ((s1 - s2) ** 2).mean() ** .5
-    bias = ((s1-s2).sum())/s2.sum() * 100
-    return {'rq75': rq75,
-            'r2': r2,
-            'rmse': rmse,
-            'bias': bias}
+    rq75 = np.percentile(np.maximum(abs(s1 / s2), abs(s2 / s1)), 75)
+    r2 = 1 - ((s2 - s1) ** 2).sum() / ((s2 - s2.mean()) ** 2).sum()  # == nash
+    rmse = ((s1 - s2) ** 2).mean() ** 0.5
+    bias = ((s1 - s2).sum()) / s2.sum() * 100
+    return {"rq75": rq75, "r2": r2, "rmse": rmse, "bias": bias}
+
 
 def accuracy(y, yhat):
     print(f"Accuracy: {accuracy_score(y, yhat)}")
     print("Classification Report:")
     print(classification_report(y, yhat))
 
-def plot_results(yobs, ypred, imps, target, mlmodel, savefigs=False, folder='docs/figures/'):
-    """    
+
+def plot_results(
+    yobs, ypred, imps, target, mlmodel, savefigs=False, folder="docs/figures/"
+):
+    """
     plot (bool): If True, plot feature importance and observed vs predicted values.
     savefigs (bool): If True, save figures plotted (plot must be True).
     """
-    
+
     # Compute statistic metrics of the cross validations
     stats_cv = stats(ypred, yobs)
-    
+
     # Feature Importance Visualization
     imps_mean = imps.median()
     imps_sortindex = imps_mean.argsort()[::-1]
 
     fig, ax = plt.subplots(1, 1, figsize=(6, 8))
-    ax.boxplot(imps.iloc[:, imps_sortindex[::-1][-12:]], vert=False, showfliers=False, labels=imps.columns[imps_sortindex[::-1][-12:]])
-    ax.set_title(f'{mlmodel}, {target}')
+    ax.boxplot(
+        imps.iloc[:, imps_sortindex[::-1][-12:]],
+        vert=False,
+        showfliers=False,
+        labels=imps.columns[imps_sortindex[::-1][-12:]],
+    )
+    ax.set_title(f"{mlmodel}, {target}")
     fig.tight_layout()
     plt.show()
 
-    bias = stats_cv['bias'].round(2)
-    rmse = stats_cv['rmse'].round(2)
-    r2 = stats_cv['r2'].round(2)
-    
+    bias = stats_cv["bias"].round(2)
+    rmse = stats_cv["rmse"].round(2)
+    r2 = stats_cv["r2"].round(2)
+
     if savefigs:
-        fig.savefig(folder+'permimp_'+target+'_'+mlmodel+'.png', dpi=300)
+        fig.savefig(folder + "permimp_" + target + "_" + mlmodel + ".png", dpi=300)
 
     # Observed vs Predicted Visualization
     fig, ax1 = plt.subplots(1, 1, dpi=300, figsize=(5, 5))
     ax1.scatter(yobs, ypred, s=5, alpha=0.5)
-    ax1.plot([0, yobs.max()], [0, yobs.max()], 'k--')
-    ax1.set_xlabel(f'Obs {target} [cm]')
-    ax1.set_ylabel(f'Pred {target} [cm]')
-    ax1.set_title(f'{mlmodel} \n BIAS: {bias:.2f}, RMSE: {rmse:.2f}, R²: {r2:.2f}')
+    ax1.plot([0, yobs.max()], [0, yobs.max()], "k--")
+    ax1.set_xlabel(f"Obs {target} [cm]")
+    ax1.set_ylabel(f"Pred {target} [cm]")
+    ax1.set_title(f"{mlmodel} \n BIAS: {bias:.2f}, RMSE: {rmse:.2f}, R²: {r2:.2f}")
     cutlim = np.percentile(yobs, 100)
     ax1.set_xlim([0, cutlim])
     ax1.set_ylim([0, cutlim])
-    ax1.set_aspect('equal', 'box')
+    ax1.set_aspect("equal", "box")
     fig.tight_layout()
     plt.show()
-    
+
     if savefigs:
-        fig.savefig(folder+'result_'+target+'_'+mlmodel+'.png', dpi=300)
-
-
-
-
+        fig.savefig(folder + "result_" + target + "_" + mlmodel + ".png", dpi=300)

--- a/src/modelling/utils.py
+++ b/src/modelling/utils.py
@@ -184,7 +184,9 @@ def kfold_cv(X, y, model, grid):
         yhat[test_index] = y_pred
 
         # Store importance scores for this fold (10 rows)
-        imps.iloc[importance_row : importance_row + 10, :] = r.importances.T  # noqa: E203
+        imps.iloc[importance_row : importance_row + 10, :] = (  # noqa: E203
+            r.importances.T
+        )
         importance_row += 10
 
         fold_number = importance_row // 10

--- a/src/prepro/dvc.yaml
+++ b/src/prepro/dvc.yaml
@@ -1,9 +1,12 @@
 stages:
   point2pol:
-    cmd: python point2pol.py
+    cmd: >-
+      python point2pol.py 
+      --input data/raw/Field_measurements/shrub_clean.shp
+      --output data/interim/field_pols.fgb
+      --epsg EPSG:27700
     deps:
       - point2pol.py
-      - data/raw/Field_measurements/shrub_clean.shp
     outs:
       - data/interim/field_pols.fgb
 
@@ -16,19 +19,25 @@ stages:
       - data/interim/rgb_sfm.tif
 
   normalize_dsm:
-    cmd: python normalize_dsm.py
+    cmd: >-
+      python normalize_dsm.py
+      --dtm data/raw/EA_1m/TL06sw_DTM_1m.tif
+      --dsm data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif
+      --output data/interim/sfm_normalized.tif
+      --crs EPSG:27700
     deps:
       - normalize_dsm.py
-      - data/raw/EA_1m/TL06sw_DTM_1m.tif
-      - data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif
     outs:
       - data/interim/sfm_normalized.tif
 
   manual_labeled:
-    cmd: python manual_labeled.py
+    cmd: >-
+      python manual_labeled.py
+      --input data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp
+      --output data/interim/manual_pols.fgb
+      --crs EPSG:27700
     deps:
       - manual_labeled.py
-      - data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp
     outs:
       - data/interim/manual_pols.fgb
 

--- a/src/prepro/manual_labeled.py
+++ b/src/prepro/manual_labeled.py
@@ -1,11 +1,10 @@
-
 import geopandas as gpd
 
 # Load the input shapefile
 df = gpd.read_file("data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp")
-df = df.to_crs('EPSG:27700')
+df = df.to_crs("EPSG:27700")
 
-df.id = df.index+1
+df.id = df.index + 1
 df.area = df.geometry.area
 
-df.to_file("data/interim/manual_pols.fgb", driver='FlatGeobuf')
+df.to_file("data/interim/manual_pols.fgb", driver="FlatGeobuf")

--- a/src/prepro/manual_labeled.py
+++ b/src/prepro/manual_labeled.py
@@ -1,10 +1,66 @@
+"""
+Process manually labeled shrub polygons and save to FlatGeobuf format.
+"""
+
+import argparse
+from pathlib import Path
 import geopandas as gpd
 
-# Load the input shapefile
-df = gpd.read_file("data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp")
-df = df.to_crs("EPSG:27700")
 
-df.id = df.index + 1
-df.area = df.geometry.area
+def process_polygons(
+    input_path: str, output_path: str, target_crs: str = "EPSG:27700"
+) -> None:
+    """Process manually labeled polygons and compute areas.
 
-df.to_file("data/interim/manual_pols.fgb", driver="FlatGeobuf")
+    Args:
+        input_path: Path to input shapefile
+        output_path: Path to save processed polygons
+        target_crs: Target coordinate reference system
+    """
+    # Load and reproject input polygons
+    df = gpd.read_file(input_path)
+    df = df.to_crs(target_crs)
+
+    # Add sequential IDs and compute areas
+    df.id = df.index + 1
+    df.area = df.geometry.area
+
+    # Save to FlatGeobuf format
+    df.to_file(output_path, driver="FlatGeobuf")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Process manually labeled shrub polygons"
+    )
+
+    parser.add_argument(
+        "--input",
+        default="data/raw/Manually_labeled/reprojected_yellow_low_shrub.shp",
+        help="Input shapefile path (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--output",
+        default="data/interim/manual_pols.fgb",
+        help="Output file path (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--crs",
+        default="EPSG:27700",
+        help="Target coordinate system (default: %(default)s)",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Ensure output directory exists
+    output_dir = Path(args.output).parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    process_polygons(args.input, args.output, args.crs)

--- a/src/prepro/normalize_dsm.py
+++ b/src/prepro/normalize_dsm.py
@@ -7,15 +7,16 @@ Created on Mon May 13 19:44:10 2024
 """
 
 import os
+
 import numpy as np
 import rasterio
 from rasterio.enums import Resampling
-from rasterio.warp import reproject, calculate_default_transform
+from rasterio.warp import calculate_default_transform, reproject
 
-dtm_path = 'data/raw/EA_1m/TL06sw_DTM_1m.tif'
-folder_path = 'data/raw/SfM'
-dsm_path = 'data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif'
-output_folder = 'data/interim'
+dtm_path = "data/raw/EA_1m/TL06sw_DTM_1m.tif"
+folder_path = "data/raw/SfM"
+dsm_path = "data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif"
+output_folder = "data/interim"
 
 
 # Read the reference TIFF
@@ -23,27 +24,30 @@ with rasterio.open(dtm_path) as dtm:
     dtm_array = dtm.read(1)  # Read the first band
     dtm_transform = dtm.transform
     dtm_crs = dtm.crs
-    
+
     # Loop through all TIFF files in the specified folder
     # for filename in os.listdir(folder_path):
     #     if filename.startswith('Strawberry_DSM_') and filename.endswith('.tif'):
-            # dsm_path = os.path.join(folder_path, filename)
-    
+    # dsm_path = os.path.join(folder_path, filename)
+
     # Open the current TIFF file in the loop
     with rasterio.open(dsm_path) as dsm:
         ref_array = dsm.read(1)
-        target_crs = 'EPSG:27700'
+        target_crs = "EPSG:27700"
         transform, width, height = calculate_default_transform(
-                    dsm.crs, target_crs, dsm.width, dsm.height, *dsm.bounds)
+            dsm.crs, target_crs, dsm.width, dsm.height, *dsm.bounds
+        )
 
         kwargs = dsm.meta.copy()
-        kwargs.update({
-            'crs': target_crs,
-            'transform': transform,
-            'width': width,
-            'height': height
-        })
-        
+        kwargs.update(
+            {
+                "crs": target_crs,
+                "transform": transform,
+                "width": width,
+                "height": height,
+            }
+        )
+
         # Create an empty array for the reprojected reference raster
         dst_array = np.empty((height, width), dtype=rasterio.float32)
 
@@ -55,9 +59,9 @@ with rasterio.open(dtm_path) as dtm:
             dst_transform=transform,
             dst_crs=target_crs,
             dst_nodata=dsm.nodata,
-            resampling=Resampling.nearest
+            resampling=Resampling.nearest,
         )
-        
+
         # Reproject the reference raster directly to match the current TIFF file
         dtm_rep, _ = reproject(
             source=dtm_array,
@@ -66,18 +70,16 @@ with rasterio.open(dtm_path) as dtm:
             src_crs=dtm_crs,
             dst_transform=transform,
             dst_crs=target_crs,
-            resampling=Resampling.nearest
+            resampling=Resampling.nearest,
         )
-        
+
         # Perform the array operation
-        
+
         result_array = dsm_array - (dtm_rep + 1)
-        result_array[dsm_array==dsm.nodata] = dsm.nodata
-        
+        result_array[dsm_array == dsm.nodata] = dsm.nodata
+
         # Prepare to save the resulting raster
         output_path = os.path.join(output_folder, "sfm_normalized.tif")
 
-        with rasterio.open(output_path, 'w', **kwargs) as out:
+        with rasterio.open(output_path, "w", **kwargs) as out:
             out.write(result_array, 1)  # Write the first band
-
-

--- a/src/prepro/normalize_dsm.py
+++ b/src/prepro/normalize_dsm.py
@@ -6,80 +6,126 @@ Created on Mon May 13 19:44:10 2024
 @author: rafbar
 """
 
-import os
-
+import argparse
+from pathlib import Path
 import numpy as np
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.warp import calculate_default_transform, reproject
 
-dtm_path = "data/raw/EA_1m/TL06sw_DTM_1m.tif"
-folder_path = "data/raw/SfM"
-dsm_path = "data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif"
-output_folder = "data/interim"
+
+def normalize_dsm(
+    dtm_path: str, dsm_path: str, output_path: str, target_crs: str = "EPSG:27700"
+) -> None:
+    """Normalize Digital Surface Model using Digital Terrain Model.
+
+    Args:
+        dtm_path: Path to Digital Terrain Model file
+        dsm_path: Path to Digital Surface Model file
+        output_path: Path to save normalized DSM
+        target_crs: Target coordinate reference system
+    """
+    # Read the reference DTM
+    with rasterio.open(dtm_path) as dtm:
+        dtm_array = dtm.read(1)  # Read the first band
+        dtm_transform = dtm.transform
+        dtm_crs = dtm.crs
+
+        # Open the DSM file
+        with rasterio.open(dsm_path) as dsm:
+            ref_array = dsm.read(1)
+            transform, width, height = calculate_default_transform(
+                dsm.crs, target_crs, dsm.width, dsm.height, *dsm.bounds
+            )
+
+            kwargs = dsm.meta.copy()
+            kwargs.update(
+                {
+                    "crs": target_crs,
+                    "transform": transform,
+                    "width": width,
+                    "height": height,
+                }
+            )
+
+            # Create empty array for reprojected reference raster
+            dst_array = np.empty((height, width), dtype=rasterio.float32)
+
+            # Reproject DSM
+            dsm_array, _ = reproject(
+                source=ref_array,
+                destination=dst_array.copy(),
+                src_transform=dsm.transform,
+                src_crs=dsm.crs,
+                dst_transform=transform,
+                dst_crs=target_crs,
+                dst_nodata=dsm.nodata,
+                resampling=Resampling.nearest,
+            )
+
+            # Reproject DTM
+            dtm_rep, _ = reproject(
+                source=dtm_array,
+                destination=dst_array.copy(),
+                src_transform=dtm_transform,
+                src_crs=dtm_crs,
+                dst_transform=transform,
+                dst_crs=target_crs,
+                resampling=Resampling.nearest,
+            )
+
+            # Calculate normalized DSM
+            result_array = dsm_array - (dtm_rep + 1)
+            result_array[dsm_array == dsm.nodata] = dsm.nodata
+
+            # Save result
+            with rasterio.open(output_path, "w", **kwargs) as out:
+                out.write(result_array, 1)
 
 
-# Read the reference TIFF
-with rasterio.open(dtm_path) as dtm:
-    dtm_array = dtm.read(1)  # Read the first band
-    dtm_transform = dtm.transform
-    dtm_crs = dtm.crs
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Normalize Digital Surface Model using Digital Terrain Model"
+    )
 
-    # Loop through all TIFF files in the specified folder
-    # for filename in os.listdir(folder_path):
-    #     if filename.startswith('Strawberry_DSM_') and filename.endswith('.tif'):
-    # dsm_path = os.path.join(folder_path, filename)
+    parser.add_argument(
+        "--dtm",
+        default="data/raw/EA_1m/TL06sw_DTM_1m.tif",
+        help="Path to DTM file (default: %(default)s)",
+    )
 
-    # Open the current TIFF file in the loop
-    with rasterio.open(dsm_path) as dsm:
-        ref_array = dsm.read(1)
-        target_crs = "EPSG:27700"
-        transform, width, height = calculate_default_transform(
-            dsm.crs, target_crs, dsm.width, dsm.height, *dsm.bounds
-        )
+    parser.add_argument(
+        "--dsm",
+        default="data/raw/SfM/StrawDSM_SfM_L1-geoid_apr24.tif",
+        help="Path to DSM file (default: %(default)s)",
+    )
 
-        kwargs = dsm.meta.copy()
-        kwargs.update(
-            {
-                "crs": target_crs,
-                "transform": transform,
-                "width": width,
-                "height": height,
-            }
-        )
+    parser.add_argument(
+        "--output",
+        default="data/interim/sfm_normalized.tif",
+        help="Output path (default: %(default)s)",
+    )
 
-        # Create an empty array for the reprojected reference raster
-        dst_array = np.empty((height, width), dtype=rasterio.float32)
+    parser.add_argument(
+        "--crs",
+        default="EPSG:27700",
+        help="Target coordinate system (default: %(default)s)",
+    )
 
-        dsm_array, _ = reproject(
-            source=ref_array,
-            destination=dst_array.copy(),
-            src_transform=dsm.transform,
-            src_crs=dsm.crs,
-            dst_transform=transform,
-            dst_crs=target_crs,
-            dst_nodata=dsm.nodata,
-            resampling=Resampling.nearest,
-        )
+    return parser.parse_args()
 
-        # Reproject the reference raster directly to match the current TIFF file
-        dtm_rep, _ = reproject(
-            source=dtm_array,
-            destination=dst_array.copy(),
-            src_transform=dtm_transform,
-            src_crs=dtm_crs,
-            dst_transform=transform,
-            dst_crs=target_crs,
-            resampling=Resampling.nearest,
-        )
 
-        # Perform the array operation
+if __name__ == "__main__":
+    args = parse_args()
 
-        result_array = dsm_array - (dtm_rep + 1)
-        result_array[dsm_array == dsm.nodata] = dsm.nodata
+    # Ensure output directory exists
+    output_dir = Path(args.output).parent
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Prepare to save the resulting raster
-        output_path = os.path.join(output_folder, "sfm_normalized.tif")
-
-        with rasterio.open(output_path, "w", **kwargs) as out:
-            out.write(result_array, 1)  # Write the first band
+    normalize_dsm(
+        dtm_path=args.dtm,
+        dsm_path=args.dsm,
+        output_path=args.output,
+        target_crs=args.crs,
+    )

--- a/src/prepro/point2pol.py
+++ b/src/prepro/point2pol.py
@@ -1,17 +1,18 @@
-
 import geopandas as gpd
 
 # Load the input shapefile
 df = gpd.read_file("data/raw/Field_measurements/shrub_clean.shp")
-df = df.to_crs('EPSG:27700')
+df = df.to_crs("EPSG:27700")
+
 
 def create_circle(row):
-    radius = row['d_mean'] / 100
-    return row['geometry'].buffer(radius)
+    radius = row["d_mean"] / 100
+    return row["geometry"].buffer(radius)
 
-df['geometry'] = df.apply(create_circle, axis=1)
-df['area'] = df.area
 
-df = df[['id', 'species', 'area', 'h_mean', 'geometry']]
+df["geometry"] = df.apply(create_circle, axis=1)
+df["area"] = df.area
 
-df.to_file("data/interim/field_pols.fgb", driver='FlatGeobuf')
+df = df[["id", "species", "area", "h_mean", "geometry"]]
+
+df.to_file("data/interim/field_pols.fgb", driver="FlatGeobuf")

--- a/src/prepro/point2pol.py
+++ b/src/prepro/point2pol.py
@@ -1,18 +1,74 @@
-import geopandas as gpd
+"""
+Convert point measurements to polygon geometries using buffer radius from field data.
+"""
 
-# Load the input shapefile
-df = gpd.read_file("data/raw/Field_measurements/shrub_clean.shp")
-df = df.to_crs("EPSG:27700")
+import argparse
+import geopandas as gpd
 
 
 def create_circle(row):
+    """Create circular buffer around point using diameter from measurements.
+
+    Args:
+        row: GeoDataFrame row containing point geometry and d_mean field
+
+    Returns:
+        Circular polygon geometry
+    """
     radius = row["d_mean"] / 100
     return row["geometry"].buffer(radius)
 
 
-df["geometry"] = df.apply(create_circle, axis=1)
-df["area"] = df.area
+def process_points(input_path: str, output_path: str, epsg: str = "EPSG:27700") -> None:
+    """Process point measurements and create polygon buffers.
 
-df = df[["id", "species", "area", "h_mean", "geometry"]]
+    Args:
+        input_path: Path to input point shapefile
+        output_path: Path to save output polygon file
+        epsg: Target coordinate system EPSG code
+    """
+    # Load and reproject input points
+    df = gpd.read_file(input_path)
+    df = df.to_crs(epsg)
 
-df.to_file("data/interim/field_pols.fgb", driver="FlatGeobuf")
+    # Create circular buffers
+    df["geometry"] = df.apply(create_circle, axis=1)
+    df["area"] = df.area
+
+    # Select output columns
+    df = df[["id", "species", "area", "h_mean", "geometry"]]
+
+    # Save to FlatGeobuf format
+    df.to_file(output_path, driver="FlatGeobuf")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Convert point measurements to polygon geometries"
+    )
+
+    parser.add_argument(
+        "--input",
+        default="data/raw/Field_measurements/shrub_clean.shp",
+        help="Input point shapefile path (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--output",
+        default="data/interim/field_pols.fgb",
+        help="Output polygon file path (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--epsg",
+        default="EPSG:27700",
+        help="Target coordinate system (default: %(default)s)",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    process_points(args.input, args.output, args.epsg)

--- a/src/treatment/las_pc_at_shrubs.py
+++ b/src/treatment/las_pc_at_shrubs.py
@@ -1,87 +1,142 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Fri Jun 21 13:24:54 2024
+Process LiDAR point clouds at shrub locations.
 
-@author: rafbar
+This script extracts LiDAR points for manually identified shrub polygons.
 """
 
-import laspy
-import geopandas as gpd
-from shapely.geometry import Point, box
-import pandas as pd
-import numpy as np
+import argparse
+import logging
 import os
+from pathlib import Path
 
-os.chdir('shrub-height')
+import geopandas as gpd
+import laspy
+import numpy as np
+from shapely.geometry import Point, box
 
-pols = gpd.read_file('data/interim/manual_pols.fgb')
-pols = pols.to_crs("EPSG:32630")
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
-shrub_points = pols.representative_point()
 
-folder = 'data/raw/LiDAR/Leaf-On'
-las_file_list = []
-for file in os.listdir(folder):
-    if file.endswith('.las'):
-        las_file_list.append(file)
+def process_las_file(
+    las_file_path: str,
+    shrub_points: gpd.GeoSeries,
+    pols: gpd.GeoDataFrame,
+    output_dir: str,
+) -> None:
+    """Process a single LAS file and extract points for each shrub polygon.
 
-dirsave = 'data/interim/lidar_leafon_manual_id'
-
-for fn in las_file_list:
-    
-    las_file_path = os.path.join(folder, fn)
-    
-    # Check if polygons are within bounds and skip if not
+    Args:
+        las_file_path: Path to LAS file
+        shrub_points: GeoSeries of representative points for shrubs
+        pols: GeoDataFrame containing shrub polygons
+        output_dir: Directory to save output files
+    """
     with laspy.open(las_file_path) as meta:
         header = meta.header
-        
-        bbox = box(header.mins[0], header.maxs[0],  header.mins[1], header.maxs[1])
+        bbox = box(header.mins[0], header.maxs[0], header.mins[1], header.maxs[1])
         points_in_check = shrub_points.within(bbox)
-        
-        block = las_file_path.split('_')[-1][:-4]
-        
+
+        block = Path(las_file_path).stem.split("_")[-1]
+
         if not any(points_in_check):
-            print('Block ' + str(block) + ' not within field measurements bounds!')
-            continue
-    
-    print('Opening block ' + str(block))
+            logging.info(f"Block {block} not within field measurements bounds!")
+            return
+
+    logging.info(f"Opening block {block}")
     las = laspy.read(las_file_path)
-    
-    print('Computing point locations')
+
+    logging.info("Computing point locations")
     lasx = las.x
     lasy = las.y
-    
+
     for _, pol in pols.iterrows():
-        
         minx, miny, maxx, maxy = pol.geometry.bounds
-        
-        mask = (
-                (lasx >= minx) & (lasx <= maxx) &
-                (lasy >= miny) & (lasy <= maxy)
-                )
-        
+
+        mask = (lasx >= minx) & (lasx <= maxx) & (lasy >= miny) & (lasy <= maxy)
+
         if mask.any():
             shrub_id = int(pol.id)
-            print('Shrub {} within block! \n Computing measurements.'.format(shrub_id))
-            
+            logging.info(f"Shrub {shrub_id} within block! \nComputing measurements.")
+
             image = las[mask]
             points = [Point(x, y) for x, y in zip(image.x, image.y)]
-            las_gdf = gpd.GeoDataFrame({'return': image.return_number.array,
-                                        'class': image.classification.array,
-                                        'z': np.array(image.z),
-                                        'R': (image.red / 65535 * 255).astype(np.uint8),
-                                        'G': (image.green / 65535 * 255).astype(np.uint8),
-                                        'B': (image.blue / 65535 * 255).astype(np.uint8),
-                                        'geometry': points})
-            las_gdf = las_gdf.set_crs('epsg:4326')
-            las_gdf = las_gdf.clip(pol.geometry)
-            las_gdf = las_gdf.to_crs('epsg:27700')
-            
-            las_gdf.to_file('{}/{}_b{}.fgb'.format(dirsave, shrub_id, block),
-                            driver='FlatGeobuf')
-            
-            print('Processed {} \n'.format(shrub_id))
+            las_gdf = gpd.GeoDataFrame(
+                {
+                    "return": image.return_number.array,
+                    "class": image.classification.array,
+                    "z": np.array(image.z),
+                    "R": (image.red / 65535 * 255).astype(np.uint8),
+                    "G": (image.green / 65535 * 255).astype(np.uint8),
+                    "B": (image.blue / 65535 * 255).astype(np.uint8),
+                    "geometry": points,
+                }
+            )
 
-        
-        
+            las_gdf = las_gdf.set_crs("epsg:4326")
+            las_gdf = las_gdf.clip(pol.geometry)
+            las_gdf = las_gdf.to_crs("epsg:27700")
+
+            output_path = Path(output_dir) / f"{shrub_id}_b{block}.fgb"
+            las_gdf.to_file(output_path, driver="FlatGeobuf")
+            logging.info(f"Processed {shrub_id}\n")
+
+
+def main(polygons_path: str, lidar_folder: str, output_dir: str) -> None:
+    """Main function to process LiDAR data for shrub polygons.
+
+    Args:
+        polygons_path: Path to polygon file
+        lidar_folder: Folder containing LAS files
+        output_dir: Output directory for results
+    """
+    # Read and process polygons
+    pols = gpd.read_file(polygons_path)
+    pols = pols.to_crs("EPSG:32630")
+    shrub_points = pols.representative_point()
+
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Process each LAS file
+    lidar_path = Path(lidar_folder)
+    las_files = list(lidar_path.glob("*.las"))
+
+    for las_file in las_files:
+        process_las_file(str(las_file), shrub_points, pols, output_dir)
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Process LiDAR point clouds at shrub locations"
+    )
+
+    parser.add_argument(
+        "--polygons",
+        default="data/interim/manual_pols.fgb",
+        help="Path to polygon file (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--lidar-folder",
+        default="data/raw/LiDAR/Leaf-On",
+        help="Folder containing LAS files (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        default="data/interim/lidar_leafon_manual_id",
+        help="Output directory for results (default: %(default)s)",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.polygons, args.lidar_folder, args.output_dir)

--- a/src/treatment/shrub_stats_las.py
+++ b/src/treatment/shrub_stats_las.py
@@ -7,15 +7,13 @@ Created on Thu Jul  4 12:17:05 2024
 """
 
 import os
-
+import argparse
 import geopandas as gpd
 import numpy as np
 
 
-os.chdir("shrub-height")
-
-
 def calculate_statistics(points):
+    """...existing docstring..."""
     stats = {}
     stats["mean"] = points.mean()
     stats["median"] = points.median()
@@ -31,48 +29,99 @@ def calculate_rmse(actual, predicted):
     return np.sqrt(np.mean((actual - predicted) ** 2))
 
 
-# Directory containing the FGB files
-src = "lidar_leafon"
-method = "field"
-directory = f"data/interim/{src}_{method}_id"
+def process_lidar_data(
+    input_dir: str,
+    polygons_path: str,
+    output_path: str,
+    src: str = "lidar_leafon",
+    method: str = "field",
+) -> None:
+    """Process LiDAR data and calculate statistics.
 
-# DataFrame to store the results
-df = gpd.read_file(f"data/interim/{method}_pols.fgb")
-df = df.sort_values(by="id").reset_index(drop=True)
-df = df.drop("geometry", axis=1)
+    Args:
+        input_dir: Directory containing the FGB files
+        polygons_path: Path to polygons file
+        output_path: Path to save output CSV
+        src: Source identifier for LiDAR data
+        method: Method identifier for processing
+    """
+    # DataFrame to store the results
+    df = gpd.read_file(polygons_path)
+    df = df.sort_values(by="id").reset_index(drop=True)
+    df = df.drop("geometry", axis=1)
 
-# Loop through each file in the directory
-for filename in os.listdir(directory):
-    if filename.endswith(".fgb"):
-        filepath = os.path.join(directory, filename)
+    # Loop through each file in the directory
+    for filename in os.listdir(input_dir):
+        if filename.endswith(".fgb"):
+            filepath = os.path.join(input_dir, filename)
 
-        # Read the FGB file
-        gdf = gpd.read_file(filepath)
+            # Read the FGB file
+            gdf = gpd.read_file(filepath)
 
-        # Extract the x and y coordinates from the geometry
-        z_ground = gdf[gdf["class"] == 2].z
-        z_canopy = gdf[gdf["class"] == 1].z
+            # Extract the x and y coordinates from the geometry
+            z_ground = gdf[gdf["class"] == 2].z
+            z_canopy = gdf[gdf["class"] == 1].z
 
-        # Calculate statistics for x and y coordinates
-        stats_ground = calculate_statistics(z_ground)
-        stats_canopy = calculate_statistics(z_canopy)
+            # Calculate statistics
+            stats_ground = calculate_statistics(z_ground)
+            stats_canopy = calculate_statistics(z_canopy)
 
-        # Combine stats and add the filename as the index
-        stats_combined = {f"ground_{k}": v for k, v in stats_ground.items()}
-        stats_combined.update({f"canopy_{k}": v for k, v in stats_canopy.items()})
+            # Combine stats and add the filename as the index
+            stats_combined = {f"ground_{k}": v for k, v in stats_ground.items()}
+            stats_combined.update({f"canopy_{k}": v for k, v in stats_canopy.items()})
 
-        # Append the stats to the results DataFrame
-        shrub_id = filename.split(".")[0].split("_")[0]
-        df.loc[df.id == float(shrub_id), stats_combined.keys()] = (
-            stats_combined.values()
-        )
+            # Append the stats to the results DataFrame
+            shrub_id = filename.split(".")[0].split("_")[0]
+            df.loc[df.id == float(shrub_id), stats_combined.keys()] = (
+                stats_combined.values()
+            )
 
-df["h_lidar"] = (df.canopy_max - df.ground_max) * 100
+    df["h_lidar"] = (df.canopy_max - df.ground_max) * 100
 
-# Compare with field measurements (for field data)
-# df['h_diff'] = df.h_lidar - df.h_mean
-# calculate_rmse(df.h_mean, df.h_lidar)
-# df[['h_mean', 'h_lidar']].corr(method='pearson')
+    # Save the results to a CSV file
+    df.to_csv(output_path)
 
-# Save the results to a CSV file
-df.to_csv(f"data/processed/stats_{method}_{src}.csv")
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Process LiDAR point clouds and calculate statistics"
+    )
+
+    parser.add_argument(
+        "--input-dir",
+        default="data/interim/lidar_leafon_field_id",
+        help="Directory containing FGB files (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--polygons",
+        default="data/interim/field_pols.fgb",
+        help="Path to polygons file (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--output",
+        default="data/processed/stats_field_lidar_leafon.csv",
+        help="Output CSV path (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--source",
+        default="lidar_leafon",
+        help="Source identifier for LiDAR data (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--method",
+        default="field",
+        help="Method identifier for processing (default: %(default)s)",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    process_lidar_data(
+        args.input_dir, args.polygons, args.output, args.source, args.method
+    )

--- a/src/treatment/shrub_stats_las.py
+++ b/src/treatment/shrub_stats_las.py
@@ -7,61 +7,67 @@ Created on Thu Jul  4 12:17:05 2024
 """
 
 import os
-import numpy as np
-import geopandas as gpd
-import pandas as pd
 
-os.chdir('shrub-height')
+import geopandas as gpd
+import numpy as np
+
+
+os.chdir("shrub-height")
+
 
 def calculate_statistics(points):
     stats = {}
-    stats['mean'] = points.mean()
-    stats['median'] = points.median()
-    stats['std'] = points.std()
-    stats['min'] = points.min()
-    stats['max'] = points.max()
-    stats['p10'] = points.quantile(0.1)
-    stats['p90'] = points.quantile(0.9)
+    stats["mean"] = points.mean()
+    stats["median"] = points.median()
+    stats["std"] = points.std()
+    stats["min"] = points.min()
+    stats["max"] = points.max()
+    stats["p10"] = points.quantile(0.1)
+    stats["p90"] = points.quantile(0.9)
     return stats
+
 
 def calculate_rmse(actual, predicted):
     return np.sqrt(np.mean((actual - predicted) ** 2))
 
+
 # Directory containing the FGB files
-src = 'lidar_leafon'
-method = 'field'
-directory = f'data/interim/{src}_{method}_id'
+src = "lidar_leafon"
+method = "field"
+directory = f"data/interim/{src}_{method}_id"
 
 # DataFrame to store the results
-df = gpd.read_file(f'data/interim/{method}_pols.fgb')
-df = df.sort_values(by='id').reset_index(drop=True)
-df = df.drop('geometry', axis=1)
+df = gpd.read_file(f"data/interim/{method}_pols.fgb")
+df = df.sort_values(by="id").reset_index(drop=True)
+df = df.drop("geometry", axis=1)
 
 # Loop through each file in the directory
 for filename in os.listdir(directory):
-    if filename.endswith('.fgb'):
+    if filename.endswith(".fgb"):
         filepath = os.path.join(directory, filename)
-        
+
         # Read the FGB file
         gdf = gpd.read_file(filepath)
-        
+
         # Extract the x and y coordinates from the geometry
-        z_ground = gdf[gdf['class']==2].z
-        z_canopy = gdf[gdf['class']==1].z
-        
+        z_ground = gdf[gdf["class"] == 2].z
+        z_canopy = gdf[gdf["class"] == 1].z
+
         # Calculate statistics for x and y coordinates
         stats_ground = calculate_statistics(z_ground)
         stats_canopy = calculate_statistics(z_canopy)
-        
-        # Combine stats and add the filename as the index
-        stats_combined = {f'ground_{k}': v for k, v in stats_ground.items()}
-        stats_combined.update({f'canopy_{k}': v for k, v in stats_canopy.items()})
-        
-        # Append the stats to the results DataFrame
-        shrub_id = filename.split('.')[0].split('_')[0]
-        df.loc[df.id==float(shrub_id), stats_combined.keys()] = stats_combined.values()
 
-df['h_lidar'] = (df.canopy_max - df.ground_max)*100
+        # Combine stats and add the filename as the index
+        stats_combined = {f"ground_{k}": v for k, v in stats_ground.items()}
+        stats_combined.update({f"canopy_{k}": v for k, v in stats_canopy.items()})
+
+        # Append the stats to the results DataFrame
+        shrub_id = filename.split(".")[0].split("_")[0]
+        df.loc[df.id == float(shrub_id), stats_combined.keys()] = (
+            stats_combined.values()
+        )
+
+df["h_lidar"] = (df.canopy_max - df.ground_max) * 100
 
 # Compare with field measurements (for field data)
 # df['h_diff'] = df.h_lidar - df.h_mean
@@ -69,8 +75,4 @@ df['h_lidar'] = (df.canopy_max - df.ground_max)*100
 # df[['h_mean', 'h_lidar']].corr(method='pearson')
 
 # Save the results to a CSV file
-df.to_csv(f'data/processed/stats_{method}_{src}.csv')
-
-
-
-
+df.to_csv(f"data/processed/stats_{method}_{src}.csv")

--- a/src/treatment/shrub_stats_sfm.py
+++ b/src/treatment/shrub_stats_sfm.py
@@ -6,43 +6,46 @@ Created on Fri Mar 22 09:32:00 2024
 """
 
 import os
+
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 import rasterio
 from rasterio.mask import mask
 
-os.chdir('shrub-height')
+os.chdir("shrub-height")
+
 
 def compute_Ps(dname, data):
-    stats_result = {}
     step = 5
     percentiles = np.arange(step, 101, step)
     return np.percentile(data, percentiles)
 
+
 def compute_stats(dname, data):
     stats_result = {}
-    stats_result[dname+'_mean'] = data.mean()
-    stats_result[dname+'_std'] = data.std() 
-    stats_result[dname+'_min'] = data.min() # np.percentile(data, [1])[0]
-    stats_result[dname+'_max'] = data.max() # np.percentile(data, [99])[0]
-    stats_result[dname+'_25th_percentile'] = np.percentile(data, [25])[0]
-    stats_result[dname+'_median'] = np.percentile(data, [50])[0]
-    stats_result[dname+'_75th_percentile'] = np.percentile(data, [75])[0]
+    stats_result[dname + "_mean"] = data.mean()
+    stats_result[dname + "_std"] = data.std()
+    stats_result[dname + "_min"] = data.min()  # np.percentile(data, [1])[0]
+    stats_result[dname + "_max"] = data.max()  # np.percentile(data, [99])[0]
+    stats_result[dname + "_25th_percentile"] = np.percentile(data, [25])[0]
+    stats_result[dname + "_median"] = np.percentile(data, [50])[0]
+    stats_result[dname + "_75th_percentile"] = np.percentile(data, [75])[0]
     return stats_result
+
 
 def get_raster_stats(polygon, raster_files):
     stats_d = {}
     print(polygon.id)
     for raster_file in raster_files:
-        dname = raster_file.split('/')[-1].split('_')[-2]
+        dname = raster_file.split("/")[-1].split("_")[-2]
         with rasterio.open(raster_file) as src:
             # If the polygon intersects the bounding box of the raster
             if not rasterio.coords.disjoint_bounds(src.bounds, polygon.geometry.bounds):
                 print(raster_file)
                 # Read the raster data that overlaps with the polygon
                 out_image, out_transform = mask(src, [polygon.geometry], crop=True)
-                
+
                 if src.count >= 3:
                     red, green, blue = out_image[:3].astype(float)
                     data = (green - red) / (green + red - blue + 1e-6)
@@ -50,7 +53,7 @@ def get_raster_stats(polygon, raster_files):
                 else:
                     no_data = src.nodata
                     data = out_image[out_image != no_data]
-                
+
                 print(data.mean())
                 # Store the results
                 if (data.size > 0) & (data.mean() != 0):
@@ -58,38 +61,34 @@ def get_raster_stats(polygon, raster_files):
                     # break
     return stats_d
 
-directory = 'data/interim'
-method = 'field'
 
-data_files = [os.path.join(directory, f) for f in os.listdir(directory)
-                if f.startswith("sfm_normalized") and 
-                f.endswith(".tif")]
+directory = "data/interim"
+method = "field"
+
+data_files = [
+    os.path.join(directory, f)
+    for f in os.listdir(directory)
+    if f.startswith("sfm_normalized") and f.endswith(".tif")
+]
 
 pols = gpd.read_file(f"data/interim/{method}_pols.fgb")
-pols = pols.sort_values(by='id').reset_index(drop=True)
+pols = pols.sort_values(by="id").reset_index(drop=True)
 
 stats_list = []
 for index, row in pols.iterrows():
     stats = get_raster_stats(row, data_files)
-    stats['id'] = int(row.id)
+    stats["id"] = int(row.id)
     stats_list.append(stats)
-    
+
 
 df = pd.DataFrame(stats_list)
 
 # Get validation height from lidar
-h_lidar = pd.read_csv(f'data/processed/stats_{method}_lidar_leafon.csv', index_col=0)
+h_lidar = pd.read_csv(f"data/processed/stats_{method}_lidar_leafon.csv", index_col=0)
 
 
-df[['area', 'h_lidar']] = h_lidar[['area', 'h_lidar']]
+df[["area", "h_lidar"]] = h_lidar[["area", "h_lidar"]]
 
-df.set_index('id', inplace=True)
+df.set_index("id", inplace=True)
 
-df.to_csv(f'data/processed/shrubs2ml_{method}.csv')
-    
-    
-    
-    
-    
-    
-    
+df.to_csv(f"data/processed/shrubs2ml_{method}.csv")

--- a/src/treatment/shrub_stats_sfm.py
+++ b/src/treatment/shrub_stats_sfm.py
@@ -6,23 +6,40 @@ Created on Fri Mar 22 09:32:00 2024
 """
 
 import os
-
+import argparse
+from pathlib import Path
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rasterio
 from rasterio.mask import mask
 
-os.chdir("shrub-height")
 
+def compute_Ps(dname: str, data: np.ndarray) -> np.ndarray:
+    """Compute percentiles of data at regular intervals.
 
-def compute_Ps(dname, data):
+    Args:
+        dname: Name of the data source
+        data: Array of values to compute percentiles for
+
+    Returns:
+        Array of percentile values
+    """
     step = 5
     percentiles = np.arange(step, 101, step)
     return np.percentile(data, percentiles)
 
 
-def compute_stats(dname, data):
+def compute_stats(dname: str, data: np.ndarray) -> dict:
+    """Calculate statistical measures for input data.
+
+    Args:
+        dname: Name of the data source
+        data: Array of values to compute statistics for
+
+    Returns:
+        Dictionary of computed statistics
+    """
     stats_result = {}
     stats_result[dname + "_mean"] = data.mean()
     stats_result[dname + "_std"] = data.std()
@@ -34,7 +51,16 @@ def compute_stats(dname, data):
     return stats_result
 
 
-def get_raster_stats(polygon, raster_files):
+def get_raster_stats(polygon: gpd.GeoDataFrame, raster_files: list) -> dict:
+    """Extract and compute statistics from raster data for a given polygon.
+
+    Args:
+        polygon: GeoDataFrame row containing polygon geometry
+        raster_files: List of paths to raster files
+
+    Returns:
+        Dictionary of computed statistics
+    """
     stats_d = {}
     print(polygon.id)
     for raster_file in raster_files:
@@ -62,33 +88,72 @@ def get_raster_stats(polygon, raster_files):
     return stats_d
 
 
-directory = "data/interim"
-method = "field"
+def process_data(input_dir: str, method: str, output_dir: str) -> None:
+    """Process SfM data and calculate statistics for polygons.
 
-data_files = [
-    os.path.join(directory, f)
-    for f in os.listdir(directory)
-    if f.startswith("sfm_normalized") and f.endswith(".tif")
-]
+    Args:
+        input_dir: Directory containing input files
+        method: Processing method identifier
+        output_dir: Directory for output files
+    """
+    data_files = [
+        os.path.join(input_dir, f)
+        for f in os.listdir(input_dir)
+        if f.startswith("sfm_normalized") and f.endswith(".tif")
+    ]
 
-pols = gpd.read_file(f"data/interim/{method}_pols.fgb")
-pols = pols.sort_values(by="id").reset_index(drop=True)
+    pols_path = Path(input_dir) / f"{method}_pols.fgb"
+    pols = gpd.read_file(pols_path)
+    pols = pols.sort_values(by="id").reset_index(drop=True)
 
-stats_list = []
-for index, row in pols.iterrows():
-    stats = get_raster_stats(row, data_files)
-    stats["id"] = int(row.id)
-    stats_list.append(stats)
+    stats_list = []
+    for _, row in pols.iterrows():
+        stats = get_raster_stats(row, data_files)
+        stats["id"] = int(row.id)
+        stats_list.append(stats)
+
+    df = pd.DataFrame(stats_list)
+
+    # Get validation height from lidar
+    lidar_path = Path(output_dir) / f"stats_{method}_lidar_leafon.csv"
+    h_lidar = pd.read_csv(lidar_path, index_col=0)
+
+    df[["area", "h_lidar"]] = h_lidar[["area", "h_lidar"]]
+    df.set_index("id", inplace=True)
+
+    output_path = Path(output_dir) / f"shrubs2ml_{method}.csv"
+    df.to_csv(output_path)
 
 
-df = pd.DataFrame(stats_list)
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Process SfM data and calculate statistics"
+    )
 
-# Get validation height from lidar
-h_lidar = pd.read_csv(f"data/processed/stats_{method}_lidar_leafon.csv", index_col=0)
+    parser.add_argument(
+        "--input-dir",
+        default="data/interim",
+        help="Directory containing input files (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--method",
+        default="field",
+        help="Processing method identifier (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        default="data/processed",
+        help="Output directory (default: %(default)s)",
+    )
+
+    return parser.parse_args()
 
 
-df[["area", "h_lidar"]] = h_lidar[["area", "h_lidar"]]
-
-df.set_index("id", inplace=True)
-
-df.to_csv(f"data/processed/shrubs2ml_{method}.csv")
+if __name__ == "__main__":
+    args = parse_args()
+    process_data(
+        input_dir=args.input_dir, method=args.method, output_dir=args.output_dir
+    )


### PR DESCRIPTION
A mostly CoPilot-generated quick refactor of the existing scripts to make them more reusable

## Key Changes
* Added if __name__ == "__main__" blocks to all scripts
* Introduced command line argument parsing with defaults
* Added type hints and docstrings to improve code clarity
* Moved hardcoded paths to command line arguments
* Updated DVC pipeline to use explicit arguments
* Made coordinate systems configurable via arguments
* Added automatic output directory creation

Applied `black` for code lint and checks with `flake8`

Next step would be a restructure of contents in `src` to make a testable package, generate some minimal unit tests and Actions for running them automatically, but didn't want to do all this in a single PR